### PR TITLE
治标不治本的办法。

### DIFF
--- a/src/call_x86.dasc
+++ b/src/call_x86.dasc
@@ -465,8 +465,8 @@ int x86_return_size(lua_State* L, int usr, const struct ctype* ct)
     lua_pop(L, 1);
 #endif
     if (ct->calling_convention == FAST_CALL) {
-        if (ret > 8) {
-            ret -=8;
+        if (ret > REGISTER_STACK_SPACE(ct)) {
+            ret -=REGISTER_STACK_SPACE(ct);
         }  else {
             ret = 0;
         }

--- a/src/call_x86.dasc
+++ b/src/call_x86.dasc
@@ -464,7 +464,13 @@ int x86_return_size(lua_State* L, int usr, const struct ctype* ct)
     }
     lua_pop(L, 1);
 #endif
-
+    if (ct->calling_convention == FAST_CALL) {
+        if (ret > 8) {
+            ret -=8;
+        }  else {
+            ret = 0;
+        }
+    }
     return ret;
 }
 

--- a/src/call_x86.dasc
+++ b/src/call_x86.dasc
@@ -465,8 +465,8 @@ int x86_return_size(lua_State* L, int usr, const struct ctype* ct)
     lua_pop(L, 1);
 #endif
     if (ct->calling_convention == FAST_CALL) {
-        if (ret > REGISTER_STACK_SPACE(ct)) {
-            ret -=REGISTER_STACK_SPACE(ct);
+        if (ret > 8) {
+            ret -=8;
         }  else {
             ret = 0;
         }


### PR DESCRIPTION
在fastcall约定里 减掉开头8字节  前提是前2个参数不使用超过8字节以上的类型下 让代码正常运行。